### PR TITLE
A CI-updated chart  summarizing stackage history

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,54 @@
+# Generate and deploy the stackage history chart
+name: Deploy chart
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Haskell
+      run: cabal update
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cabal/store
+        key: deploy-chart-${{ github.sha }}
+        restore-keys: deploy-chart-
+
+    - name: Create chart
+      run: |
+        cabal run stackage-history-chart
+        cp -f chart*.svg html/chart.svg
+
+    - uses: actions/upload-pages-artifact@v1
+      with:
+        path: html
+
+  # Deploy job, see https://github.com/actions/deploy-pages/tree/f81ad71d2e78487340fb3a94726f2a6050466efd#readme
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages:    write   # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Deploy to GitHub Pages
+      id:   deployment
+      uses: actions/deploy-pages@v2

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages:
+  stackage-history-chart
+
+with-compiler: ghc-9.4.5

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,13 @@
+<html>
+  <style>
+    body {
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: space-around;
+    }
+  </style>
+  <body>
+    <img src="chart.svg"></img>
+  </body>
+</html>

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-21.1
+
+packages:
+- stackage-history-chart
+
+extra-deps:
+- Chart-cairo-1.9.3

--- a/stackage-history-chart/src/Main.hs
+++ b/stackage-history-chart/src/Main.hs
@@ -26,10 +26,9 @@
 -- However, we can also use the (slower) proper YAML parser.
 --
 
+-- imports from standard libraries
 import Control.Monad
   ( guard )
-import Control.Monad.Extra
-  ( fromMaybeM, unlessM )
 import Control.Monad.Except
   ( MonadError(..), ExceptT, runExceptT )
 import Control.Monad.IO.Class
@@ -59,8 +58,6 @@ import Data.Text
   ( Text )
 import Data.Traversable
   ( forM )
-import Data.Yaml
-  ( (.:), (.:?), FromJSON(..), pattern Object, decodeThrow )
 import System.Directory
   ( doesDirectoryExist, getCurrentDirectory, listDirectory )
 import System.Exit
@@ -69,6 +66,14 @@ import System.FilePath
   ( (</>), (<.>), dropExtension )
 import Text.Read
   ( readMaybe )
+
+-- extra
+import Control.Monad.Extra
+  ( fromMaybeM, unlessM )
+
+-- yaml
+import Data.Yaml
+  ( (.:), (.:?), FromJSON(..), pattern Object, decodeThrow )
 
 -- time
 import Data.Time.Clock
@@ -219,8 +224,8 @@ runM m = runExceptT (unM m) >>= \case
 main :: IO ()
 main = do
   putStrLn "stackage-history-chart (C) Andreas Abel 2023"
-  -- putStrLn =<< getCurrentDirectory
 
+  putStrLn "Parsing latest snapshots"
   -- Get LTS snapshots (latest major versions).
   ltss <- runM latestLTSs
   -- mapM_ putStrLn ltss
@@ -329,7 +334,7 @@ main = do
 reportSnapshot :: String -> Snapshot -> IO ()
 reportSnapshot name snapshot = do
   putStrLn $ unwords $ concat
-    [ [ name ]
+    [ [ "-", name ]
     , maybe [] (\ ghc -> [ "for GHC", printGHC ghc ]) $ snapshotGHC snapshot
     , [ "has", show $ length $ snapshotPackages snapshot, "packages" ]
     ]

--- a/stackage-history-chart/src/Main.hs
+++ b/stackage-history-chart/src/Main.hs
@@ -1,0 +1,436 @@
+-- |
+-- We expect to be called from the root of the stackage-snapshorts repo.
+-- This repo has the following structure:
+--
+--   - @lts/MAJOR/MINOR.yaml@, e.g. @lts/21/1.yaml@
+--
+--   - @nightly/YEAR/MONTH/DAY.yaml@, e.g. @nightly/2023/7/3.yaml@
+--
+-- We first need to map each major GHC version to its latest snapshot.
+-- To this end, we investigate the following candidates:
+--
+--    - @lt/MAJOR/MAXMINOR.yaml@ for each @MAJOR@ LTS version
+--
+--    - @nightly/MAXYEAR/MAXMONTH/MAXDAY.yaml@
+--
+-- The @.yaml@ files have the following fields of interest:
+--
+--   - compiler: ghc-MAJOR.MAJOR2.MINOR
+--   - packages: [{ hackage: PACKAGE-VERSION@SHA, ...}]
+--
+-- Poor man's parsing could go through lines and pick the following:
+--
+--   - e.g. @compiler: ghc-7.8.4@ (one per file), may be indented
+--   - e.g. @- hackage: Agda-2.6.3@sha256:7979e244ee659b9663305b5c545cff090f2309ed08d3e4ea3e7120579b8f047e,36742@ (many)
+--
+-- However, we can also use the (slower) proper YAML parser.
+--
+
+import Control.Monad
+  ( guard )
+import Control.Monad.Extra
+  ( fromMaybeM, unlessM )
+import Control.Monad.Except
+  ( MonadError(..), ExceptT, runExceptT )
+import Control.Monad.IO.Class
+  ( MonadIO, liftIO )
+import Data.Bifunctor
+  ( first, second )
+import Data.ByteString qualified as BS
+import Data.Char
+  ( isDigit )
+import Data.Foldable
+  ( forM_ )
+import Data.Functor
+  ( (<&>) )
+import Data.List
+  ( intercalate, sort, sortBy )
+import Data.Map qualified as Map
+import Data.Map
+  ( Map )
+import Data.Maybe
+  ( catMaybes, listToMaybe, mapMaybe )
+import Data.Set qualified as Set
+import Data.Set
+  ( Set )
+import Data.Text    qualified as Text
+import Data.Text.IO qualified as Text
+import Data.Text
+  ( Text )
+import Data.Traversable
+  ( forM )
+import Data.Yaml
+  ( (.:), (.:?), FromJSON(..), pattern Object, decodeThrow )
+import System.Directory
+  ( doesDirectoryExist, getCurrentDirectory, listDirectory )
+import System.Exit
+  ( die )
+import System.FilePath
+  ( (</>), (<.>), dropExtension )
+import Text.Read
+  ( readMaybe )
+
+-- time
+import Data.Time.Clock
+  ( getCurrentTime )
+import Data.Time.Format
+  ( defaultTimeLocale, formatTime )
+
+-- colour, default, lens
+import Control.Lens
+  ( (.~) )
+import Data.Default
+  ( def )
+import Data.Colour
+  ( AlphaColour, opaque )
+import Data.Colour.SRGB
+  ( sRGB24read )
+
+-- Chart and Chart-cairo
+import Graphics.Rendering.Chart
+  ( Layout
+  , pattern AxisVisibility
+  , pattern BarsFixGap, pattern BarsStacked, pattern FillStyleSolid, pattern LORows
+  , laxis_generate
+  , layout_bottom_axis_visibility, layout_legend, layout_plots, layout_title, layout_y_axis
+  , layoutToRenderable
+  , legend_orientation
+  , plot_bars_item_styles, plot_bars_spacing, plot_bars_style, plot_bars_titles, plot_bars_values
+  , plotBars
+  , scaledAxis
+  )
+import Graphics.Rendering.Chart.Backend.Cairo
+  ( pattern FileOptions, pattern PDF, pattern SVG
+  , renderableToFile
+  )
+
+-- * Configuration
+
+-- | Path to LTS snapshots from repository root.
+ltsPath :: FilePath
+ltsPath = "lts"
+
+-- | Path to nightly snapshots from repository root.
+nightlyPath :: FilePath
+nightlyPath = "nightly"
+
+-- | Size of generated images.
+dim :: (Int, Int)
+dim = (800, 600)
+
+-- | Palette to color blocks in chart.
+colors :: [AlphaColour Double]
+colors = colors_divergent_13
+
+-- | Palette generated at <https://www.learnui.design/tools/data-color-picker.html#divergent>
+-- with maximal color intensity.
+colors_divergent_13 :: [AlphaColour Double]
+colors_divergent_13 = map opaque $ cycle $ map sRGB24read $ reverse $
+  "#00876c" :
+  "#3d9a70" :
+  "#64ad73" :
+  "#89bf77" :
+  "#afd17c" :
+  "#d6e184" :
+  "#fff18f" :
+  "#fdd576" :
+  "#fbb862" :
+  "#f59b56" :
+  "#ee7d4f" :
+  "#e35e4e" :
+  "#d43d51" :
+  []
+
+-- * Types
+
+-- ** Snapshot files
+
+-- | Fragment of the grammar of stackage snapshots.
+data Snapshot = Snapshot
+  { packages :: [SnapshotPackage]
+      -- ^ The list of versioned packages included in the snapshot.
+  , compiler :: Maybe Text
+      -- ^ Info about the compiler version for this snapshot (early format).
+  , resolver :: Maybe SnapshotResolver
+      -- ^ Info about the compiler version for this snapshot (late format).
+  } deriving Show
+
+instance Eq  Snapshot where _ == _      = undefined
+instance Ord Snapshot where compare _ _ = undefined
+
+-- | Fragment of the @"packages"@ entries of a stackage snapshot.
+data SnapshotPackage = SnapshotPackage
+  { hackage :: Text
+      -- ^ The hackage identifier (plus SHA) of a package.
+  } deriving Show
+
+-- | The @"resolver"@ entry of a stackage snapshot.
+data SnapshotResolver = SnapshotResolver
+  { compiler :: Text
+      -- ^ The Haskell compiler for this snapshot, e.g. @ghc-9.6.2@.
+  } deriving Show
+
+-- ** Extracted information from snapshots
+
+-- | A LTS version.
+data LTS = LTS { major, minor :: Int }
+  deriving (Eq, Ord, Show)
+
+-- | A nightly version.
+data Nightly = Nightly { year, month, day :: Int }
+  deriving (Eq, Ord, Show)
+
+-- | A GHC major version.
+data GHC = GHC { major, minor :: Int }
+  deriving (Eq, Ord, Show)
+
+-- | Name of a Haskell package.
+newtype Package = Package { packageName :: Text }
+  deriving (Eq, Ord, Show)
+
+-- ** Monad
+
+-- | Our monad.
+newtype M a = M { unM :: ExceptT Err IO a }
+  deriving (Functor, Applicative, Monad, MonadIO, MonadError Err)
+
+data Err
+  = NoNightly
+      -- ^ Directory @nightly@ not found at the root.
+  | NoNightlyYear
+      -- ^ No directory @nightly/YEAR@ found at the root.
+  | NoNightlyMonth
+      -- ^ No directory @nightly/MAXYEAR/MONTH@ found at the root.
+  | NoNightlyDay
+      -- ^ No file @nightly/MAXYEAR/MAXMONTH/DAY.EXTENSION@ found at the root.
+  | NoLTS
+      -- ^ Directory @lts@ not found at the root.
+  | NoLTSMinor Int
+      -- ^ Directory @lts/Int@ has no files @MINOR.EXTENSION@.
+  deriving Show
+
+runM :: M a -> IO a
+runM m = runExceptT (unM m) >>= \case
+  Left err -> die $ show err
+  Right a  -> return a
+
+-- * Code
+
+main :: IO ()
+main = do
+  putStrLn "stackage-history-chart (C) Andreas Abel 2023"
+  -- putStrLn =<< getCurrentDirectory
+
+  -- Get LTS snapshots (latest major versions).
+  ltss <- runM latestLTSs
+  -- mapM_ putStrLn ltss
+  ghcLTSs :: [(GHC,(LTS,Snapshot))]
+    -- We ignore the snapshots that have no "compiler: ghc-..." entry.
+    <- catMaybes <$>
+      forM ltss \ lts -> do
+        s :: Snapshot
+          <- decodeThrow =<< BS.readFile (ltsToFilePath lts)
+        reportSnapshot (ltsToID lts) s
+        pure $ snapshotGHC s <&> (,(lts,s))
+
+  -- Get latest nightly snapshot.
+  nightly <- runM latestNightly
+  -- putStrLn latest
+  nightlySnapshot :: Snapshot
+    <- decodeThrow =<< BS.readFile (nightlyToFilePath nightly)
+  -- mapM_ (Text.putStrLn . packageName) $ snapshotPackages nightlySnapshot
+  reportSnapshot (nightlyToID nightly) nightlySnapshot
+
+  -- For each major GHC version, get the latest snapshot.
+  -- Nightly overwrites a potential LTS snapshot with the same GHC major version.
+  let
+    ghcToSnapshot :: Map GHC Snapshot
+    ghcToSnapshot =
+      -- Nightly
+      maybe id (\ ghc -> Map.insert ghc nightlySnapshot) (snapshotGHC nightlySnapshot)
+      -- LTSs
+      $ fmap snd $ Map.fromListWith max ghcLTSs
+
+    ghcToPackages :: [(GHC, [Package])]
+    ghcToPackages = Map.toList $ fmap snapshotPackages ghcToSnapshot
+
+  -- Maximum number of packages in snapshot.
+  let
+    maxPackages :: Int
+    maxPackages = maximum $ map (length . snd) ghcToPackages
+
+  -- Map each package to its minium GHC version.
+  let
+    pkgToMin :: Map Package GHC
+    pkgToMin =
+      Map.map minimum $
+      Map.fromListWith (<>) $
+      concatMap (\ (ghc, pkgs) -> map (,Set.singleton ghc) pkgs) $
+      ghcToPackages
+
+  -- Map each GHC version to number packages per smaller-or-equal GHC version.
+  let
+    pkgMaps :: [(GHC, [Int])]
+    pkgMaps = flip map ghcToPackages $ second $
+      Map.elems .
+      Map.fromListWith (+) .
+      map (\ pkg -> (pkgToMin Map.! pkg, 1))
+
+  -- Prepare a chart visualizing pkgMaps.
+
+  today :: String
+    <- formatTime defaultTimeLocale "%F" <$> getCurrentTime
+
+  let
+    ghcs :: [String]
+    ghcs = map (printGHC . fst) pkgMaps
+
+    vals :: [(Double, [Int])]
+    vals = map (first ghcToDouble) pkgMaps
+
+    valsDouble :: [(Double, [Double])]
+    valsDouble = map (second (map fromIntegral)) vals
+
+    nBars = length ghcs
+
+    bars = plot_bars_titles      .~ ghcs
+         $ plot_bars_style       .~ BarsStacked
+         $ plot_bars_spacing     .~ BarsFixGap 0 0
+         $ plot_bars_item_styles .~ map (\ c -> (FillStyleSolid c, Just def)) colors
+         $ plot_bars_values      .~ valsDouble
+         $ def
+
+    maxHeight :: Double
+    maxHeight = fromIntegral maxPackages
+
+    layout :: Layout Double Double
+    layout = layout_title  .~ ("Stackage LTS packages by age in terms of GHC version as of " ++ today)
+           $ layout_legend .~ Just (legend_orientation .~ LORows nBars $ def)
+           $ layout_plots  .~ [ plotBars bars ]
+           $ layout_bottom_axis_visibility  .~ AxisVisibility True False False  -- only line, no numbers
+           -- $ layout_left_axis_visibility    .~ AxisVisibility True False False  -- off
+           -- $ layout_right_axis_visibility   .~ def                              -- on
+           $ layout_y_axis . laxis_generate .~ scaledAxis def (0, maxHeight)         -- scaledAxis forces Double values
+           $ def -- :: Layout1 LocalTime Double
+
+  let
+    renderable = layoutToRenderable layout
+    writeImage typ name = do
+      putStrLn $ unwords [ "Writing", name ]
+      renderableToFile (FileOptions dim typ) name renderable
+    svg = ("chart-" ++ today ++ ".svg")
+    pdf = ("chart-" ++ today ++ ".pdf")
+
+  _ <- writeImage SVG svg
+  _ <- writeImage PDF pdf
+  return ()
+
+-- | Print some basic statistics about a snapshot.
+reportSnapshot :: String -> Snapshot -> IO ()
+reportSnapshot name snapshot = do
+  putStrLn $ unwords $ concat
+    [ [ name ]
+    , maybe [] (\ ghc -> [ "for GHC", printGHC ghc ]) $ snapshotGHC snapshot
+    , [ "has", show $ length $ snapshotPackages snapshot, "packages" ]
+    ]
+
+snapshotGHC :: Snapshot -> Maybe GHC
+snapshotGHC s = listToMaybe $ mapMaybe (parseGHC . Text.unpack) $ catMaybes [ s.compiler, (.compiler) <$> s.resolver ]
+
+parseGHC :: String -> Maybe GHC
+parseGHC s = do
+  let (ghc, ver) = splitAt 4 s
+  guard $ ghc == "ghc-"
+  case break ('.' ==) ver of
+    (hd, '.':tl) -> do
+      maj <- readMaybe hd
+      min <- readMaybe $ takeWhile isDigit tl
+      return $ GHC maj min
+    _ -> Nothing
+
+printGHC :: GHC -> String
+printGHC (GHC major minor) = show major <> "." <> show minor
+
+snapshotPackages :: Snapshot -> [Package]
+snapshotPackages = map (parsePackageID . hackage) . packages
+
+parsePackageID :: Text -> Package
+parsePackageID = Package . Text.init . Text.dropWhileEnd (/= '-') . Text.takeWhile (/= '@')
+
+ltsToID :: LTS -> String
+ltsToID (LTS major minor) = "lts-" <> show major <> "." <> show minor
+
+ltsToFilePath :: LTS -> FilePath
+ltsToFilePath (LTS major minor) =
+  ltsPath </> show major </> show minor <.> "yaml"
+
+nightlyToID :: Nightly -> String
+nightlyToID (Nightly year month day) = intercalate "-" $ "nightly" : map show [year, month, day]
+
+nightlyToFilePath :: Nightly -> FilePath
+nightlyToFilePath (Nightly year month day) =
+  nightlyPath </> show year </> show month </> show day <.> "yaml"
+
+
+-- | Get the stem to the latest nightly, e.g. @nightly/2023/7/3@.
+latestNightly :: M Nightly
+latestNightly = do
+  -- @nightly@
+  unlessM (liftIO $ doesDirectoryExist nightlyPath) $ throwError NoNightly
+  -- @nightly/2023@
+  year <- fromMaybeM (throwError NoNightlyYear) $ maxNumericEntry nightlyPath
+  let nightlyYear = nightlyPath </> show year
+  -- @nightly/2023/7@
+  month <- fromMaybeM (throwError NoNightlyMonth) $ maxNumericEntry nightlyYear
+  let nightlyYearMonth = nightlyYear </> show month
+  -- @nightly/2023/7/3@
+  day <- fromMaybeM (throwError NoNightlyDay) $ maxNumericEntry nightlyYearMonth
+  return $ Nightly year month day
+
+latestLTSs :: M [LTS]
+latestLTSs = do
+  -- @lts@
+  unlessM (liftIO $ doesDirectoryExist ltsPath) $ throwError NoLTS
+  -- @lts/MAJOR@
+  majors <- sort . mapMaybe readMaybe <$> liftIO (listDirectory ltsPath)
+  forM majors \ major -> do
+    -- @lts/21@
+    let ltsMajor = ltsPath </> show major
+    -- @lts/21/1@
+    minor <- fromMaybeM (throwError $ NoLTSMinor major) $ maxNumericEntry ltsMajor
+    return $ LTS major minor
+
+-- * Chart preparation
+
+-- | Scale to unit interval
+ghcToDouble :: GHC -> Double
+ghcToDouble g = fromIntegral (ghcToInt g) / 22
+
+-- | 7.8--9.4 yields 1--21
+ghcToInt :: GHC -> Int
+ghcToInt (GHC major minor) = ((major - 7) * 12 + minor - 8) + 1 -- `div` 2
+
+-- * Utilities
+
+-- | Given a directory, select the entries that are numeric after dropping the extension,
+--   and return the maximal one.
+maxNumericEntry :: MonadIO io => FilePath -> io (Maybe Int)
+maxNumericEntry root =
+  listToMaybe . sortBy (flip compare) . mapMaybe readMaybe . map dropExtension <$> do
+    liftIO $ listDirectory root
+
+-- YAML parsing
+
+instance FromJSON Snapshot where
+  parseJSON (Object v) = Snapshot
+    <$> v .:  "packages"
+    <*> v .:? "compiler"
+    <*> v .:? "resolver"
+
+instance FromJSON SnapshotPackage where
+  parseJSON (Object v) = SnapshotPackage
+    <$> v.: "hackage"
+
+instance FromJSON SnapshotResolver where
+  parseJSON (Object v) = SnapshotResolver
+    <$> v.: "compiler"

--- a/stackage-history-chart/stackage-history-chart.cabal
+++ b/stackage-history-chart/stackage-history-chart.cabal
@@ -1,0 +1,35 @@
+cabal-version: 3.8
+name: stackage-history-chart
+version: 0
+license: MIT
+author: Andreas Abel
+
+executable stackage-history-chart
+  main-is: Main.hs
+  hs-source-dirs: src
+  build-depends:
+      Chart
+    , Chart-cairo
+    , aeson
+    , base
+    , bytestring
+    , colour >= 2.3.6
+    , containers
+    , data-default
+    , directory
+    , extra
+    , filepath
+    , lens
+    , mtl
+    , text
+    , time
+    , yaml
+  default-language:
+    GHC2021
+  default-extensions:
+    BlockArguments
+    DuplicateRecordFields
+    LambdaCase
+    PatternSynonyms
+    OverloadedRecordDot
+    OverloadedStrings


### PR DESCRIPTION
Create a chart of the latest snapshots for each major GHC version.
The result is this: https://andreasabel.github.io/stackage-snapshots/
It is updated by each push via CI.
Each column represents one GHC version and is partitioned into blocks representing a GHC version <= the current one.  Thus, we can see how many packages from the previous snapshots survive a GHC bump.

@snoyberg: I figured this repo was the natural home for such an analysis as naturally CI can keep the picture up-to-date here.  

CC @juhp who was interested in this code.
