### PR TITLE
stackage-history-chart: bumps: lts to 22.0, CI actions to latest

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Create chart
       run: |
         stack run
         cp -f chart*.svg html/chart.svg
 
-    - uses: actions/upload-pages-artifact@v1
+    - uses: actions/upload-pages-artifact@v3
       with:
         path: html
 
@@ -42,4 +42,4 @@ jobs:
 
     - name: Deploy to GitHub Pages
       id:   deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+stack*.yaml.lock

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,4 @@
-resolver: lts-21.9
+resolver: lts-22.0
 
 packages:
 - stackage-history-chart
-
-extra-deps:
-- Chart-cairo-1.9.3


### PR DESCRIPTION
This bumps versions in stack.yaml and the CI for the chart generator.
No changes otherwise.
Tested successfully on my fork.